### PR TITLE
Fixed bug where rdkit would generate MemoryError for rule 1.13.11_02 …

### DIFF
--- a/minedatabase/pickaxe.py
+++ b/minedatabase/pickaxe.py
@@ -357,7 +357,7 @@ class Pickaxe:
                                   + rule_name)
                             print(text_rxn)
                             print(reactant_atoms, product_atoms)
-                except ValueError as e:
+                except (ValueError, MemoryError) as e:
                     print(e)
                     print("Error Processing Rule: " + rule_name)
                     continue


### PR DESCRIPTION
…and quit when doing MP. Added exception to ignore it.